### PR TITLE
Api34 compatibility

### DIFF
--- a/app-extensions/.gitrepo
+++ b/app-extensions/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:Bandyer/Android-App-Extensions.git
 	branch = master
-	commit = e1f2e8058e2b0c75e45c0eac3e2d4a7f2d52259e
-	parent = 2e75b5767cec7c38c923ba1db6b5873502ff2644
+	commit = b6ac676149f3d03d5db140de2a394fa7523395a0
+	parent = 502b9c8df4f48d508cb59ae98b150c247db4f15d
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.6

--- a/app-extensions/.gitrepo
+++ b/app-extensions/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:Bandyer/Android-App-Extensions.git
 	branch = master
-	commit = b6ac676149f3d03d5db140de2a394fa7523395a0
-	parent = 502b9c8df4f48d508cb59ae98b150c247db4f15d
+	commit = a33dc93edc6b8a27b3ac875949e36a6895c4b119
+	parent = ec78160c382a4d2e69a41098b3ca2998c6b44116
 	method = merge
 	cmdver = 0.4.6

--- a/app-extensions/app-configuration/src/main/java/com/kaleyra/app_configuration/activities/ImageTextEditActivity.kt
+++ b/app-extensions/app-configuration/src/main/java/com/kaleyra/app_configuration/activities/ImageTextEditActivity.kt
@@ -16,7 +16,6 @@
 package com.kaleyra.app_configuration.activities
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -112,7 +111,7 @@ class ImageTextEditActivity : ScrollAwareToolbarActivity() {
 
     override fun onBackPressed() {
         if (hasChangedSettings()) {
-            AlertDialog.Builder(this, R.style.ThemeOverlay_App_MaterialAlertDialog)
+            androidx.appcompat.app.AlertDialog.Builder(this, R.style.ThemeOverlay_App_MaterialAlertDialog)
                 .setMessage(R.string.pref_settings_save_confirmation_message)
                 .setPositiveButton(R.string.pref_settings_save_confirmation_message_confirmation) { dialog, _ ->
                     dialog.dismiss()

--- a/app-extensions/app-configuration/src/main/java/com/kaleyra/app_configuration/activities/MockUserDetailsSettingsActivity.kt
+++ b/app-extensions/app-configuration/src/main/java/com/kaleyra/app_configuration/activities/MockUserDetailsSettingsActivity.kt
@@ -16,7 +16,6 @@
 package com.kaleyra.app_configuration.activities
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -179,7 +178,7 @@ class MockUserDetailsSettingsActivity : ScrollAwareToolbarActivity() {
 
     override fun onBackPressed() {
         if (hasChangedSettings()) {
-            AlertDialog.Builder(this, R.style.ThemeOverlay_App_MaterialAlertDialog)
+            androidx.appcompat.app.AlertDialog.Builder(this, R.style.ThemeOverlay_App_MaterialAlertDialog)
                 .setMessage(R.string.pref_settings_save_confirmation_message)
                 .setPositiveButton(R.string.pref_settings_save_confirmation_message_confirmation) { dialog, _ ->
                     dialog.dismiss()

--- a/app-extensions/app-utilities/src/main/res/values/strings.xml
+++ b/app-extensions/app-utilities/src/main/res/values/strings.xml
@@ -25,4 +25,7 @@
     <string name="notification_permission_message" translatable="false">Notification permission is required, please allow notification permissions.</string>
     <string name="notification_permission_app_settings" translatable="false">Notification permission is required, please allow notification permissions from app settings.</string>
 
+    <string name="fullscreen_intent_permission" translatable="false">Fullscreen Intent Permission</string>
+    <string name="fullscreen_intent_permission_message" translatable="false">It is required to allow\nfullscreen intent permission\nin order to receive incoming calls properly,\notherwise incoming calls will be shown as\nplain notifications and could be lost.</string>
+
 </resources>

--- a/app/src/main/java/com/kaleyra/demo_video_sdk/LoginActivity.kt
+++ b/app/src/main/java/com/kaleyra/demo_video_sdk/LoginActivity.kt
@@ -151,7 +151,6 @@ class LoginActivity : CollapsingToolbarActivity(), OnQueryTextListener {
 
     override fun onRefresh() {
         itemAdapter.clear()
-        setRefreshing(true)
         binding!!.loading.visibility = View.VISIBLE
         // Fetch the sample users you can use to login with.
         lifecycleScope.launch {

--- a/app/src/main/java/com/kaleyra/demo_video_sdk/MainActivity.kt
+++ b/app/src/main/java/com/kaleyra/demo_video_sdk/MainActivity.kt
@@ -360,22 +360,19 @@ class MainActivity : CollapsingToolbarActivity(), OnQueryTextListener, OnRefresh
         selectedUsersItemAdapter.add(NoUserSelectedItem())
 
         lifecycleScope.launch {
-            restApi.listUsers()
-                .filter { it != LoginManager.getLoggedUser(this@MainActivity) }
-                .forEach {
-                    binding!!.loading.visibility = View.GONE
-                    // Add each user(except the logged one) to the recyclerView adapter to be displayed in the list.
-                    usersList.add(UserSelectionItem(it))
-                    itemAdapter!!.set(usersList)
-                    for (userSelected in calleeSelected) {
-                        selectUser(userSelected, usersList.indexOf(UserSelectionItem(userSelected)))
-                    }
-                    if (searchView != null) itemAdapter!!.filter(searchView!!.query)
-                    setRefreshing(false)
+            // Fetch the sample users you can use to login with.
+            // Add each user(except the logged one) to the recyclerView adapter to be displayed in the list.
+            restApi.listUsers().filter { it != LoginManager.getLoggedUser(this@MainActivity) }.apply {
+                usersList.addAll(map { UserSelectionItem(it) })
+                itemAdapter!!.setNewList(usersList)
+                for (userSelected in calleeSelected) {
+                    selectUser(userSelected, usersList.indexOf(UserSelectionItem(userSelected)))
                 }
+                searchView?.query?.let { itemAdapter!!.filter(searchView!!.query) }
+                binding!!.loading.visibility = View.GONE
+                setRefreshing(false)
+            }
         }
-        // Fetch the sample users you can use to login with.
-
     }
 
     override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {

--- a/app/src/main/java/com/kaleyra/demo_video_sdk/MainActivity.kt
+++ b/app/src/main/java/com/kaleyra/demo_video_sdk/MainActivity.kt
@@ -43,6 +43,7 @@ import com.kaleyra.app_configuration.activities.ConfigurationActivity
 import com.kaleyra.app_configuration.model.CallOptionsType
 import com.kaleyra.app_configuration.model.Configuration
 import com.kaleyra.app_utilities.notification.NotificationProxy
+import com.kaleyra.app_utilities.notification.requestFullscreenPermissionActivityApi34
 import com.kaleyra.app_utilities.notification.requestPushNotificationPermissionApi33
 import com.kaleyra.app_utilities.storage.ConfigurationPrefsManager
 import com.kaleyra.app_utilities.storage.LoginManager
@@ -76,6 +77,8 @@ import com.mikepenz.fastadapter.extensions.ExtensionsFactories
 import com.mikepenz.fastadapter.listeners.ItemFilterListener
 import com.mikepenz.fastadapter.select.SelectExtension
 import com.mikepenz.fastadapter.select.SelectExtensionFactory
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.filter
@@ -107,7 +110,7 @@ class MainActivity : CollapsingToolbarActivity(), OnQueryTextListener, OnRefresh
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         configuration = ConfigurationPrefsManager.getConfiguration(this)
-        requestPushNotificationPermissionApi33()
+        requestPushNotificationPermissionApi33 { MainScope().launch { delay(1500); requestFullscreenPermissionActivityApi34() }  }
 
         // inflate main layout and keep a reference to it in case of use with dpad navigation
         setContentView(layout.activity_main)

--- a/app/src/main/java/com/kaleyra/demo_video_sdk/ui/activities/CollapsingToolbarActivity.kt
+++ b/app/src/main/java/com/kaleyra/demo_video_sdk/ui/activities/CollapsingToolbarActivity.kt
@@ -100,7 +100,7 @@ abstract class CollapsingToolbarActivity : BaseActivity(), OnRefreshListener {
         val environment = ConfigurationPrefsManager.getConfiguration(this).environment
         val region = ConfigurationPrefsManager.getConfiguration(this).region
         appTitle = String.format(resources.getString(R.string.app_name_with_version), "v$version")
-        val envTextView = SpannableString("\n@${environment}-${region}\n")
+        val envTextView = SpannableString("\n@${environment}-${region}\nBuilt with API${applicationInfo.targetSdkVersion}\n")
         envTextView.setSpan(AbsoluteSizeSpan(textSizeH4), 0, envTextView.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
         val infoSpan = SpannableString("\n$portraitTitle")
         infoSpan.setSpan(AbsoluteSizeSpan(textSizeH3), 0, infoSpan.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,7 +35,7 @@ dependencyResolutionManagement {
         maven { url 'https://maven.bandyer.com/releases' }
     }
 
-    def catalogVersion = "2024.06.00"
+    def catalogVersion = "2024.07.01"
 
     versionCatalogs {
         create("kaleyraCatalog") {

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/ConferenceUIExtensions.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/ConferenceUIExtensions.kt
@@ -14,6 +14,8 @@ import com.kaleyra.video_common_ui.notification.NotificationManager
 import com.kaleyra.video_common_ui.utils.CallExtensions
 import com.kaleyra.video_common_ui.utils.CallExtensions.shouldShowAsActivity
 import com.kaleyra.video_common_ui.utils.CallExtensions.showOnAppResumed
+import com.kaleyra.video_common_ui.utils.DeviceUtils
+import com.kaleyra.video_common_ui.utils.extensions.ContextExtensions.canUseFullScreenIntentCompat
 import com.kaleyra.video_common_ui.utils.extensions.ContextExtensions.hasConnectionServicePermissions
 import com.kaleyra.video_extension_audio.extensions.CollaborationAudioExtensions.enableCallSounds
 import com.kaleyra.video_utils.ContextRetainer
@@ -105,11 +107,19 @@ internal object ConferenceUIExtensions {
 
             val notification = when {
                 CallExtensions.isIncoming(state, participants) -> {
-                    CallNotificationProducer.buildIncomingCallNotification(participants, callActivityClazz, isCallServiceRunning = false)
+                    CallNotificationProducer.buildIncomingCallNotification(
+                        participants,
+                        callActivityClazz,
+                        isCallServiceRunning = false,
+                        enableCallStyle = !DeviceUtils.isSmartGlass && ContextRetainer.context.canUseFullScreenIntentCompat())
                 }
 
                 CallExtensions.isOutgoing(state, participants) -> {
-                    CallNotificationProducer.buildOutgoingCallNotification(participants, callActivityClazz, isCallServiceRunning = false)
+                    CallNotificationProducer.buildOutgoingCallNotification(
+                        participants,
+                        callActivityClazz,
+                        isCallServiceRunning = false,
+                        enableCallStyle = !DeviceUtils.isSmartGlass && ContextRetainer.context.canUseFullScreenIntentCompat())
                 }
 
                 else -> return@combine

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/callservice/CallForegroundService.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/callservice/CallForegroundService.kt
@@ -7,9 +7,14 @@ import androidx.annotation.RequiresApi
 internal interface CallForegroundService {
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    fun getForegroundServiceType(hasScreenSharingInput: Boolean): Int {
-        val inputsFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE else 0
+    fun getForegroundServiceType(
+        hasCameraPermission: Boolean,
+        hasMicrophonePermission: Boolean,
+        hasScreenSharingInput: Boolean
+    ): Int {
+        val cameraFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hasCameraPermission) ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA else 0
+        val microphoneFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hasMicrophonePermission) ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE else 0
         val screenSharingFlag = if (hasScreenSharingInput) ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION else 0
-        return ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or inputsFlag or screenSharingFlag
+        return ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL or cameraFlag or microphoneFlag or screenSharingFlag
     }
 }

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/callservice/CallForegroundServiceWorker.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/callservice/CallForegroundServiceWorker.kt
@@ -47,7 +47,7 @@ internal class CallForegroundServiceWorker(
         streamsManager.bind(call)
         participantManager.bind(call)
         streamsAudioManager.bind(call)
-        callNotificationProducer.bind(call)
+        callNotificationProducer.bind(call, service)
         callNotificationProducer.listener = callNotificationListener
 
         call.state

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/connectionservice/KaleyraCallConnectionService.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/connectionservice/KaleyraCallConnectionService.kt
@@ -18,7 +18,9 @@ import com.kaleyra.video_common_ui.callservice.CallForegroundService
 import com.kaleyra.video_common_ui.callservice.CallForegroundServiceWorker
 import com.kaleyra.video_common_ui.connectionservice.ContactsController.createOrUpdateConnectionServiceContact
 import com.kaleyra.video_common_ui.contactdetails.ContactDetailsManager.combinedDisplayName
+import com.kaleyra.video_common_ui.mapper.InputMapper.hasAudioInput
 import com.kaleyra.video_common_ui.mapper.InputMapper.hasScreenSharingInput
+import com.kaleyra.video_common_ui.mapper.InputMapper.hasInternalCameraInput
 import com.kaleyra.video_extension_audio.extensions.CollaborationAudioExtensions.disableAudioRouting
 import com.kaleyra.video_extension_audio.extensions.CollaborationAudioExtensions.enableAudioRouting
 import com.kaleyra.video_utils.logging.PriorityLogger
@@ -27,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
@@ -179,16 +182,16 @@ class KaleyraCallConnectionService : ConnectionService(), CallForegroundService,
 
     override fun onNewNotification(call: Call, notification: Notification, id: Int) {
         notificationJob?.cancel()
-        notificationJob = flowOf(call)
-            .hasScreenSharingInput()
-            .onEach { hasScreenSharingPermission ->
-                runCatching {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) startForeground(id, notification, getForegroundServiceType(hasScreenSharingPermission))
-                    else startForeground(id, notification)
-                }
-            }
-            .launchIn(coroutineScope)
+        notificationJob = combine(
+                call.hasInternalCameraInput(),
+                call.hasAudioInput(),
+                call.hasScreenSharingInput()
+            ) { hasCameraPermission, hasMicPermission, hasScreenSharingPermission ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) startForeground(id, notification, getForegroundServiceType(hasCameraPermission, hasMicPermission, hasScreenSharingPermission))
+                else startForeground(id, notification)
+            }.launchIn(coroutineScope)
     }
+
 
     override fun onSilence() {
         CallSound.stop(instantly = true)

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/mapper/InputMapper.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/mapper/InputMapper.kt
@@ -20,6 +20,7 @@ import com.kaleyra.video.conference.Call
 import com.kaleyra.video.conference.Input
 import com.kaleyra.video.conference.Stream
 import com.kaleyra.video_common_ui.call.CameraStreamConstants
+import com.kaleyra.video_common_ui.mapper.InputMapper.toCameraVideoInput
 import com.kaleyra.video_common_ui.mapper.ParticipantMapper.toMe
 import com.kaleyra.video_common_ui.utils.FlowUtils.flatMapLatestNotNull
 import kotlinx.coroutines.flow.Flow
@@ -103,6 +104,33 @@ object InputMapper {
     fun Flow<Call>.hasScreenSharingInput(): Flow<Boolean> =
         this.flatMapLatest { it.inputs.availableInputs }
             .map { inputs -> inputs.any { it is Input.Video.Screen.My } }
+
+    /**
+     * Utility function to detect whenever a screen sharing input is available
+     * @receiver Flow<Call> the call flow
+     * @return Flow<Boolean> flow emitting true whenever a screen sharing input is currently available
+     */
+    fun Call.hasScreenSharingInput(): Flow<Boolean> =
+        this.inputs.availableInputs
+            .map { inputs -> inputs.any { it is Input.Video.Screen.My } }
+
+    /**
+     * Utility function to detect whenever an internal video input is available
+     * @receiver Flow<Call> the call flow
+     * @return Flow<Boolean> flow emitting true whenever an internal video input is currently available
+     */
+    fun Call.hasInternalCameraInput(): Flow<Boolean> =
+        this.inputs.availableInputs
+            .map { inputs -> inputs.any { it is Input.Video.Camera.Internal } }
+
+    /**
+     * Utility function to detect whenever an audio input is available
+     * @receiver Flow<Call> the call flow
+     * @return Flow<Boolean> flow emitting true whenever an audio input is currently available
+     */
+    fun Call.hasAudioInput(): Flow<Boolean> =
+        this.inputs.availableInputs
+            .map { inputs -> inputs.any { it is Input.Audio } }
 
     fun Flow<Call>.toAudioInput(): Flow<Input.Audio> =
         this.flatMapLatest { it.inputs.availableInputs }

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/notification/CallNotification.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/notification/CallNotification.kt
@@ -31,6 +31,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.kaleyra.video_common_ui.R
 import com.kaleyra.video_common_ui.utils.PendingIntentExtensions
+import com.kaleyra.video_common_ui.utils.extensions.ContextExtensions.canUseFullScreenIntentCompat
 import com.kaleyra.video_utils.HostAppInfo
 
 /**
@@ -259,7 +260,7 @@ class CallNotification {
 
             color?.let { builder.setColor(it) }
             contentIntent?.also { builder.setContentIntent(it) }
-            fullscreenIntent?.also { builder.setFullScreenIntent(it, true) }
+            fullscreenIntent?.takeIf { context.canUseFullScreenIntentCompat() }?.also { builder.setFullScreenIntent(it, true) }
 
             var screenShareAction: NotificationCompat.Action? = null
             screenShareIntent?.also {
@@ -368,7 +369,7 @@ class CallNotification {
 
             color?.let { builder.setColor(it) }
             contentIntent?.also { builder.setContentIntent(it) }
-            fullscreenIntent?.also { builder.setFullScreenIntent(it, true) }
+            fullscreenIntent?.takeIf { context.canUseFullScreenIntentCompat() }?.also { builder.setFullScreenIntent(it, true) }
             screenShareIntent?.also {
                 val screenShareAction = Notification.Action.Builder(
                     Icon.createWithResource(context, R.drawable.ic_kaleyra_screen_share),

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/notification/CallNotificationManager.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/notification/CallNotificationManager.kt
@@ -62,6 +62,7 @@ internal interface CallNotificationManager {
      * @param isGroupCall True if the call is group call, false otherwise
      * @param activityClazz The call ui activity class
      * @param isHighPriority True to set the notification with high priority, false otherwise
+     * @param isCallServiceRunning True if call service is running, false otherwise
      * @return Notification
      */
     fun buildIncomingCallNotification(
@@ -69,8 +70,8 @@ internal interface CallNotificationManager {
         isGroupCall: Boolean,
         activityClazz: Class<*>,
         isHighPriority: Boolean,
-        enableCallStyle: Boolean = !DeviceUtils.isSmartGlass,
-        isCallServiceRunning: Boolean = true
+        isCallServiceRunning: Boolean,
+        enableCallStyle: Boolean,
     ): Notification {
         val context = ContextRetainer.context
 
@@ -106,14 +107,15 @@ internal interface CallNotificationManager {
      * @param username The callee/caller
      * @param isGroupCall True if the call is group call, false otherwise
      * @param activityClazz The call ui activity class
+     * @param isCallServiceRunning True if call service is running, false otherwise
      * @return Notification
      */
     fun buildOutgoingCallNotification(
         username: String,
         isGroupCall: Boolean,
         activityClazz: Class<*>,
-        enableCallStyle: Boolean = !DeviceUtils.isSmartGlass,
-        isCallServiceRunning: Boolean = true
+        isCallServiceRunning: Boolean = true,
+        enableCallStyle: Boolean,
     ): Notification {
         val context = ContextRetainer.context
         val userText = if (isGroupCall) context.resources.getString(R.string.kaleyra_notification_outgoing_group_call) else username
@@ -156,7 +158,7 @@ internal interface CallNotificationManager {
         isSharingScreen: Boolean,
         isConnecting: Boolean,
         activityClazz: Class<*>,
-        enableCallStyle: Boolean = !DeviceUtils.isSmartGlass
+        enableCallStyle: Boolean
     ): Notification {
         val context = ContextRetainer.context
         val resources = context.resources

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/notification/ChatNotification.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/notification/ChatNotification.kt
@@ -33,6 +33,7 @@ import androidx.core.graphics.drawable.toBitmap
 import com.google.android.material.color.MaterialColors
 import com.kaleyra.video_common_ui.R
 import com.kaleyra.video_common_ui.utils.BitmapUtils.toBitmap
+import com.kaleyra.video_common_ui.utils.extensions.ContextExtensions.canUseFullScreenIntentCompat
 import com.kaleyra.video_utils.HostAppInfo
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -265,7 +266,7 @@ internal class ChatNotification {
                 builder.addAction(markAsReadAction)
             }
 //            deleteIntent?.also { builder.setDeleteIntent(it) }
-            fullscreenIntent?.also { builder.setFullScreenIntent(it, true) }
+            fullscreenIntent?.takeIf { context.canUseFullScreenIntentCompat() }?.also { builder.setFullScreenIntent(it, true) }
 
             MaterialColors
                 .getColor(context, R.attr.colorSecondary, -1)

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/termsandconditions/notification/TermsAndConditionsNotification.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/termsandconditions/notification/TermsAndConditionsNotification.kt
@@ -23,6 +23,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.kaleyra.video_common_ui.R
+import com.kaleyra.video_common_ui.utils.extensions.ContextExtensions.canUseFullScreenIntentCompat
 import com.kaleyra.video_utils.HostAppInfo
 
 internal class TermsAndConditionsNotification {
@@ -77,7 +78,7 @@ internal class TermsAndConditionsNotification {
             }
 
             contentIntent?.also { builder.setContentIntent(it) }
-            fullscreenIntent?.also { builder.setFullScreenIntent(it, true) }
+            fullscreenIntent?.takeIf { context.canUseFullScreenIntentCompat() }?.also { builder.setFullScreenIntent(it, true) }
             deleteIntent?.also { builder.setDeleteIntent(it) }
 
             return builder.build()

--- a/video-common-ui/src/main/java/com/kaleyra/video_common_ui/utils/extensions/ContextExtensions.kt
+++ b/video-common-ui/src/main/java/com/kaleyra/video_common_ui/utils/extensions/ContextExtensions.kt
@@ -21,8 +21,8 @@ import android.app.Activity
 import android.app.ActivityManager
 import android.app.AppOpsManager
 import android.app.KeyguardManager
+import android.app.NotificationManager
 import android.content.Context
-import android.content.Context.ACTIVITY_SERVICE
 import android.content.ContextWrapper
 import android.content.Intent
 import android.content.res.Configuration
@@ -364,6 +364,15 @@ object ContextExtensions {
     private fun Context.hasPermission(permission: String): Boolean {
         return PermissionChecker.checkSelfPermission(applicationContext, permission) == PermissionChecker.PERMISSION_GRANTED
     }
+
+    /**
+     * Check whether the fullscreen intent permission is granted or not
+     * @receiver Context the context used to check the permission
+     * @return Boolean true if fullscreen intent permission is granted, false otherwise
+     */
+    fun Context.canUseFullScreenIntentCompat() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).canUseFullScreenIntent()
+    } else true
 
     /**
      * Go back to launcher activity if this function's caller is the solely task for the app

--- a/video-common-ui/src/test/java/com/kaleyra/video_common_ui/callservice/CallForegroundServiceTest.kt
+++ b/video-common-ui/src/test/java/com/kaleyra/video_common_ui/callservice/CallForegroundServiceTest.kt
@@ -15,33 +15,97 @@ class CallForegroundServiceTest {
 
     @Test
     fun getForegroundServiceType_phoneCallFlagSet() {
-        val serviceType = callForegroundService.getForegroundServiceType(false)
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = false,
+            hasMicrophonePermission = false,
+            hasScreenSharingInput = false
+        )
         assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL)
     }
 
     @Test
     @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.R])
+    fun cameraPermissionTrue_getForegroundServiceType_cameraFlagSet() {
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = true,
+            hasMicrophonePermission = false,
+            hasScreenSharingInput = false
+        )
+        assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA)
+    }
+
+    @Test
+    @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.R])
+    fun cameraPermissionFalse_getForegroundServiceType_cameraFlagNotSet() {
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = false,
+            hasMicrophonePermission = false,
+            hasScreenSharingInput = false
+        )
+        assertEquals(0, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA)
+    }
+
+    @Test
+    @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.R])
+    fun microphonePermissionTrue_getForegroundServiceType_microphoneFlagSet() {
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = false,
+            hasMicrophonePermission = true,
+            hasScreenSharingInput = false
+        )
+        assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+    }
+
+    @Test
+    @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.R])
+    fun microphonePermissionFalse_getForegroundServiceType_microphoneFlagNotSet() {
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = false,
+            hasMicrophonePermission = false,
+            hasScreenSharingInput = false
+        )
+        assertEquals(0, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+    }
+
+    @Test
+    @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.R])
     fun apiHigherThan30_getForegroundServiceType_cameraAndMicFlagsSet() {
-        val serviceType = callForegroundService.getForegroundServiceType(false)
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = true,
+            hasMicrophonePermission = true,
+            hasScreenSharingInput = false
+        )
         assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE, serviceType and (ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE))
     }
 
     @Test
     @Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.Q])
     fun apiLowerThan30_getForegroundServiceType_cameraAndMicFlagsNotSet() {
-        val serviceType = callForegroundService.getForegroundServiceType(false)
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = true,
+            hasMicrophonePermission = true,
+            hasScreenSharingInput = false
+        )
         assertEquals(0, serviceType and (ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE))
     }
 
     @Test
     fun hasScreenSharingInputTrue_getForegroundServiceType_mediaProjectionFlagSet() {
-        val serviceType = callForegroundService.getForegroundServiceType(true)
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = false,
+            hasMicrophonePermission = false,
+            hasScreenSharingInput = true
+        )
         assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION)
     }
 
     @Test
     fun hasScreenSharingInputFalse_getForegroundServiceType_mediaProjectionFlagNotSet() {
-        val serviceType = callForegroundService.getForegroundServiceType(false)
+        val serviceType = callForegroundService.getForegroundServiceType(
+            hasCameraPermission = false,
+            hasMicrophonePermission = false,
+            hasScreenSharingInput = false
+        )
         assertEquals(0, serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION)
     }
 }

--- a/video-common-ui/src/test/java/com/kaleyra/video_common_ui/callservice/CallForegroundServiceWorkerTest.kt
+++ b/video-common-ui/src/test/java/com/kaleyra/video_common_ui/callservice/CallForegroundServiceWorkerTest.kt
@@ -45,7 +45,7 @@ class CallForegroundServiceWorkerTest {
         mockkConstructor(StreamsManager::class)
         mockkConstructor(ParticipantManager::class)
         mockkConstructor(StreamsAudioManager::class)
-        every { anyConstructed<CallNotificationProducer>().bind(callMock) } returns Unit
+        every { anyConstructed<CallNotificationProducer>().bind(callMock, any()) } returns Unit
         every { anyConstructed<FileShareNotificationProducer>().bind(callMock) } returns Unit
         every { anyConstructed<ScreenShareOverlayProducer>().bind(callMock) } returns Unit
         every { anyConstructed<CameraStreamManager>().bind(callMock) } returns Unit
@@ -77,7 +77,7 @@ class CallForegroundServiceWorkerTest {
         }
         val callForegroundServiceWorker = CallForegroundServiceWorker(mockk(relaxed = true), this, listener)
         callForegroundServiceWorker.bind(mockk(relaxed = true), callMock)
-        verify(exactly = 1) { anyConstructed<CallNotificationProducer>().bind(callMock) }
+        verify(exactly = 1) { anyConstructed<CallNotificationProducer>().bind(callMock, any()) }
         verify(exactly = 1) { anyConstructed<CameraStreamManager>().bind(callMock) }
         verify(exactly = 1) { anyConstructed<StreamsManager>().bind(callMock) }
         verify(exactly = 1) { anyConstructed<ParticipantManager>().bind(callMock) }
@@ -96,7 +96,7 @@ class CallForegroundServiceWorkerTest {
         }
         val callForegroundServiceWorker = CallForegroundServiceWorker(mockk(relaxed = true), this, listener)
         callForegroundServiceWorker.bind(mockk(relaxed = true), callMock)
-        verify(exactly = 1) { anyConstructed<CallNotificationProducer>().bind(callMock) }
+        verify(exactly = 1) { anyConstructed<CallNotificationProducer>().bind(callMock, any()) }
         verify(exactly = 1) { anyConstructed<CameraStreamManager>().bind(callMock) }
         verify(exactly = 1) { anyConstructed<StreamsManager>().bind(callMock) }
         verify(exactly = 1) { anyConstructed<ParticipantManager>().bind(callMock) }

--- a/video-common-ui/src/test/java/com/kaleyra/video_common_ui/callservice/KaleyraCallServiceTest.kt
+++ b/video-common-ui/src/test/java/com/kaleyra/video_common_ui/callservice/KaleyraCallServiceTest.kt
@@ -238,7 +238,7 @@ class KaleyraCallServiceTest {
         assertEquals(10, shadowOf(service).lastForegroundNotificationId)
         assertEquals(notification, shadowOf(notificationManager).getNotification(10))
         assertNotEquals(0, notification.flags and Notification.FLAG_FOREGROUND_SERVICE)
-        assertEquals(service!!.getForegroundServiceType(false), service!!.foregroundServiceType)
+        assertEquals(service!!.getForegroundServiceType(false, false, false), service!!.foregroundServiceType)
         unmockkObject(AppLifecycle)
     }
 

--- a/video-common-ui/src/test/java/com/kaleyra/video_common_ui/connectionservice/KaleyraCallConnectionServiceTest.kt
+++ b/video-common-ui/src/test/java/com/kaleyra/video_common_ui/connectionservice/KaleyraCallConnectionServiceTest.kt
@@ -191,7 +191,7 @@ class KaleyraCallConnectionServiceTest {
         )
         assertNotEquals(0, notification.flags and Notification.FLAG_FOREGROUND_SERVICE)
         assertEquals(
-            service!!.getForegroundServiceType(false),
+            service!!.getForegroundServiceType(false, false, false),
             service!!.foregroundServiceType
         )
     }

--- a/video-common-ui/src/test/java/com/kaleyra/video_common_ui/notification/call/CallNotificationManagerTest.kt
+++ b/video-common-ui/src/test/java/com/kaleyra/video_common_ui/notification/call/CallNotificationManagerTest.kt
@@ -240,78 +240,19 @@ class CallNotificationManagerTest {
     }
 
     @Test
-    fun deviceIsSmartphone_buildOngoingCallNotification_callStyleEnabled() {
-        every { DeviceUtils.isSmartGlass } returns false
+    fun callNotificationManager_buildOngoingCallNotification_callStyleEnabled() {
         callNotificationManager.buildOngoingCallNotification(
             "",
             isLink = false,
             isGroupCall = false,
             isCallRecorded = false,
             isSharingScreen = false,
-            isConnecting = false, activityClazz = this::class.java
+            isConnecting = false,
+            activityClazz = this::class.java,
+            enableCallStyle = true
         )
         verify(exactly = 1) {
             anyConstructed<CallNotification.Builder>().enableCallStyle(true)
-        }
-    }
-
-    @Test
-    fun deviceIsSmartglass_buildOngoingCallNotification_callStyleDisabled() {
-        every { DeviceUtils.isSmartGlass } returns true
-        callNotificationManager.buildOngoingCallNotification(
-             "",
-            isLink = false,
-            isGroupCall = false,
-            isCallRecorded = false,
-            isSharingScreen = false,
-            isConnecting = false, activityClazz = this::class.java
-        )
-        verify(exactly = 1) {
-            anyConstructed<CallNotification.Builder>().enableCallStyle(false)
-        }
-    }
-
-    @Test
-    fun deviceIsSmartphone_buildOutgoingCallNotification_callStyleEnabled() {
-        every { DeviceUtils.isSmartGlass } returns false
-        callNotificationManager.buildOutgoingCallNotification(
-            username = "", isGroupCall = false, activityClazz = this::class.java
-        )
-        verify(exactly = 1) {
-            anyConstructed<CallNotification.Builder>().enableCallStyle(true)
-        }
-    }
-
-    @Test
-    fun deviceIsSmartglass_buildOutgoingCallNotification_callStyleDisabled() {
-        every { DeviceUtils.isSmartGlass } returns true
-        callNotificationManager.buildOutgoingCallNotification(
-            username = "", isGroupCall = false, activityClazz = this::class.java
-        )
-        verify(exactly = 1) {
-            anyConstructed<CallNotification.Builder>().enableCallStyle(false)
-        }
-    }
-
-    @Test
-    fun deviceIsSmartphone_buildIncomingCallNotification_callStyleEnabled() {
-        every { DeviceUtils.isSmartGlass } returns false
-        callNotificationManager.buildIncomingCallNotification(
-            username = "", isGroupCall = false, activityClazz = this::class.java, false
-        )
-        verify(exactly = 1) {
-            anyConstructed<CallNotification.Builder>().enableCallStyle(true)
-        }
-    }
-
-    @Test
-    fun deviceIsSmartglass_buildIncomingCallNotification_callStyleDisabled() {
-        every { DeviceUtils.isSmartGlass } returns true
-        callNotificationManager.buildIncomingCallNotification(
-            username = "", isGroupCall = false, activityClazz = this::class.java, false
-        )
-        verify(exactly = 1) {
-            anyConstructed<CallNotification.Builder>().enableCallStyle(false)
         }
     }
 

--- a/video-common-ui/src/test/java/com/kaleyra/video_common_ui/notification/call/CallNotificationProducerTest.kt
+++ b/video-common-ui/src/test/java/com/kaleyra/video_common_ui/notification/call/CallNotificationProducerTest.kt
@@ -150,10 +150,13 @@ class CallNotificationProducerTest {
     fun testNotifyIncomingCall() = runTest(UnconfinedTestDispatcher()) {
         mockkObject(CallNotificationProducer) {
             every { CallExtensions.isIncoming(any(), any()) } returns true
+            every { CallExtensions.isOutgoing(any(), any()) } returns false
+            every { CallExtensions.isOngoing(any(), any()) } returns false
+            every { contextMock.canUseFullScreenIntentCompat() } returns true
             coEvery { CallNotificationProducer.buildIncomingCallNotification(any(), any(), any(), any()) } returns incomingCallNotification
             val callNotificationProducer = CallNotificationProducer(backgroundScope)
             callNotificationProducer.listener = listener
-            callNotificationProducer.bind(callMock, mockk())
+            callNotificationProducer.bind(callMock, mockk(relaxed = true))
             val participants = callMock.participants.value
             val activityClazz = callMock.activityClazz
             coVerify(exactly = 1) { ContactDetailsManager.refreshContactDetails(*listOf("otherUserId", "myUserId").toTypedArray()) }
@@ -440,10 +443,13 @@ class CallNotificationProducerTest {
 
     @Test
     fun oneToOneCall_buildOngoingCallNotification_isGroupCallIsFalse() = runTest(UnconfinedTestDispatcher()) {
+        every { CallExtensions.isIncoming(any(), any()) } returns false
+        every { CallExtensions.isOutgoing(any(), any()) } returns false
         every { CallExtensions.isOngoing(any(), any()) } returns true
+        every { contextMock.canUseFullScreenIntentCompat() } returns true
         every { participantsMock.others } returns listOf(otherParticipantMock)
         val callNotificationProducer = CallNotificationProducer(backgroundScope)
-        callNotificationProducer.bind(callMock, mockk())
+        callNotificationProducer.bind(callMock, mockk(relaxed = true))
         verify(exactly = 1) { NotificationManager.buildOngoingCallNotification(any(), any(), isGroupCall = false, any(), any(),  any(), any(), any()) }
     }
 
@@ -479,9 +485,12 @@ class CallNotificationProducerTest {
     @Test
     fun sharingScreenNotActive_buildOngoingCallNotification_isSharingScreenFalse() = runTest(UnconfinedTestDispatcher()) {
         every { inputsMock.availableInputs } returns MutableStateFlow(setOf())
+        every { CallExtensions.isIncoming(any(), any()) } returns false
+        every { CallExtensions.isOutgoing(any(), any()) } returns false
         every { CallExtensions.isOngoing(any(), any()) } returns true
+        every { contextMock.canUseFullScreenIntentCompat() } returns true
         val callNotificationProducer = CallNotificationProducer(backgroundScope)
-        callNotificationProducer.bind(callMock, mockk())
+        callNotificationProducer.bind(callMock, mockk(relaxed = true))
         verify(exactly = 1) { NotificationManager.buildOngoingCallNotification(any(), any(), any(), any(), isSharingScreen = false, any(), any(), any()) }
     }
 

--- a/video-sdk/src/main/java/com/kaleyra/video_sdk/call/PhoneCallActivity.kt
+++ b/video-sdk/src/main/java/com/kaleyra/video_sdk/call/PhoneCallActivity.kt
@@ -203,7 +203,10 @@ internal class PhoneCallActivity : FragmentActivity(), ProximityCallActivity, Se
 
     private fun handleIntentAction(intent: Intent): Boolean {
         return when (intent.extras?.getString(CallNotificationExtra.NOTIFICATION_ACTION_EXTRA)) {
-            CallNotificationActionReceiver.ACTION_ANSWER, CallNotificationActionReceiver.ACTION_HANGUP -> {
+            CallNotificationActionReceiver.ACTION_ANSWER -> {
+                // This parameter, passed as false from connection service provisional notification
+                // prevents that the answer intent is executed before granting or denying the
+                // phone permission, needed for the starting of the connection service
                 val isCallServiceRunning = intent.extras?.getBoolean(IS_CALL_SERVICE_RUNNING_EXTRA, true) ?: true
                 if (isCallServiceRunning) {
                     forwardIntentToReceiver(intent, CallNotificationActionReceiver::class.java)


### PR DESCRIPTION
## demo app
- updated catalog to target api 34 for sdk and demo app
- added fullscreen intent permission request on demo app
- display target api on demo app
- fixed some alert dialog theme in demo app
- managed get users rest rate limits in demo app

## sdk 
- fix foreground service type set on call services start foreground request properly, fixing a crash that was run catched, preventing the start of the service in foreground
- manage full screen intent denied permission in order not to add fullscreen intent to notification as well as not enable call style in this case
- enable call style for notification only if a foreground service has started or full screen intent permission has been requested
- trigger media projection popup on android 14 disabling the possibility to set app only mode